### PR TITLE
feat. 발주 시스템 설정

### DIFF
--- a/src/constants/orderItemState.js
+++ b/src/constants/orderItemState.js
@@ -1,0 +1,5 @@
+export default {
+  ordered: 0,
+  cancel: 1,
+  complete: 2,
+};

--- a/src/controller/place.order.items.controller.js
+++ b/src/controller/place.order.items.controller.js
@@ -1,4 +1,5 @@
 import { PlaceOrderItemsService } from '../service/place.order.items.service';
+import { Messages } from '../error/messages.js';
 
 export class PlaceOrderItemsController {
   _placeOrderItemsService = new PlaceOrderItemsService();
@@ -13,20 +14,35 @@ export class PlaceOrderItemsController {
   // 발주서 만들기
   create = async (req, res) => {
     try {
-      const { itemName, amount } = req.body;
-      if (!itemName || !amount)
-        throw new Error('메뉴의 이름과 수량은 필수 값입니다.');
-      const placeOrderSuccess = await this._placeOrderItemsService.create(
-        itemName,
+      const { itemId, amount } = req.body;
+      const { code, data, message } = await this._placeOrderItemsService.create(
+        itemId,
         amount,
       );
-      const orderId = placeOrderSuccess[0].insertId;
-      res.status(200).json({
-        message: `발주번호${orderId}로 ${itemName}이 ${amount}개 발주신청 되었습니다.`,
-      });
+      res
+        .status(code)
+        .json({ ...(data && { data }), ...(message && { message }) });
     } catch (e) {
       console.log(e);
       res.status(500).json({ errorMessage: e.message });
+    }
+  };
+
+  // 주문 수정은 취소, 완료 두 가지 선택만 받을 수 있다.
+  // 주문을 수정하려면 주문 id를 받아와야한다.(생성된 pk)
+  update = async (req, res) => {
+    try {
+      const { orderId, state } = req.body;
+      const { code, data, message } = await this._placeOrderItemsService.create(
+        orderId,
+        state,
+      );
+      res
+        .status(code)
+        .json({ ...(data && { data }), ...(message && { message }) });
+    } catch (e) {
+      console.log(e);
+      res.status(500).json({ errorMessage: Messages.ServerError });
     }
   };
 }

--- a/src/repository/items.repository.js
+++ b/src/repository/items.repository.js
@@ -12,17 +12,17 @@ export class ItemsRepository {
     return allItems;
   };
 
-  getItemById = id => {
-    const [findByIdItem] = this.connection.execute(
+  getItemById = async id => {
+    const [row] = await this.connection.execute(
       'SELECT * FROM item WHERE id = ?',
       [id],
     );
-    return findByIdItem;
+    return row[0];
   };
 
   getItemByName = async name => {
-    const [findByNameItem] = await this.connection.execute(
-      'SELECT * FROM item WHERE name = ?',
+    const findByNameItem = await this.connection.execute(
+      'SELECT * FROM `item` WHERE name = ?',
       [name],
     );
     return findByNameItem;

--- a/src/repository/place.order.items.repository.js
+++ b/src/repository/place.order.items.repository.js
@@ -1,4 +1,5 @@
 import { DatabaseConnection } from '../db.js';
+import orderItemState from '../constants/orderItemState.js';
 
 export class PlaceOrderItemsRepository {
   connection;
@@ -7,18 +8,26 @@ export class PlaceOrderItemsRepository {
     this.connection = new DatabaseConnection().getConnection();
   }
 
-  create = async (itemName, amount) => {
-    const findByidName = await this.connection.execute(
-      'SELECT * FROM item WHERE name = ?',
-      [itemName],
+  create = async (itemId, amount, state) => {
+    const [createdReceipt] = await this.connection.execute(
+      'INSERT INTO place_order_item (item_id, amount, state, created_at, updated_at) VALUES (?, ?, ?, NOW(), NOW())',
+      [itemId, amount, state],
     );
-    if (!findByidName.length) throw new Error('존재하지 않는 메뉴입니다.');
-    else {
-      const itemId = findByidName[0][0].id;
-      return this.connection.execute(
-        'INSERT INTO place_order_item (item_id, amount, state, created_at, updated_at) VALUES (?, ?, ?, NOW(), NOW())',
-        [itemId, amount, 0],
-      );
-    }
+    return createdReceipt;
+  };
+
+  findReceipt = async id => {
+    const [orderReceipt] = await this.connection.execute(
+      'SELECT * FROM place_order_item where (id) VALUES (?)',
+      [id],
+    );
+    return orderReceipt;
+  };
+
+  updateState = async (id, state) => {
+    return await this.connection.execute(
+      'UPDATE place_order_item set state = ? WHERE id = ?',
+      [state, id],
+    );
   };
 }

--- a/src/routes/place.order.items.route.js
+++ b/src/routes/place.order.items.route.js
@@ -5,5 +5,6 @@ const router = Router();
 const placeOrderItemsController = new PlaceOrderItemsController();
 
 router.post('/', placeOrderItemsController.create);
+router.put('/', placeOrderItemsController.update);
 
 export default router;

--- a/src/service/place.order.items.service.js
+++ b/src/service/place.order.items.service.js
@@ -1,13 +1,115 @@
 import { PlaceOrderItemsRepository } from '../repository/place.order.items.repository';
+import { ItemsRepository } from '../repository/items.repository';
+import { Messages } from '../error/messages';
+import { ValidationCheck } from '../utils/validationCheck';
+import orderItemState from '../constants/orderItemState.js';
 
 export class PlaceOrderItemsService {
   _placeOrderItemsRepository = new PlaceOrderItemsRepository();
+  _itemRepo = new ItemsRepository();
 
-  create = async (itemName, amount) => {
-    if (typeof itemName !== 'string' || typeof amount !== 'number') {
-      throw new Error('itemName은 문자, amount는 숫자여야 합니다.');
+  create = async (id, amount) => {
+    if (!id) {
+      return {
+        code: 400,
+        message: Messages.WrongName,
+      };
+    }
+    if (!amount || amount <= 0) {
+      return {
+        code: 400,
+        message: Messages.WrongAmount,
+      };
+    }
+    const findItem = await this._itemRepo.getItemById(id);
+    if (!findItem) {
+      return {
+        code: 400,
+        message: Messages.NoneExist,
+      };
+    }
+    return {
+      code: 200,
+      data: await this._placeOrderItemsRepository.create(
+        findItem.id,
+        amount,
+        orderItemState.ordered,
+      ),
+    };
+  };
+
+  // 주문이 수정되는 경우
+  // 1. 발주한 물품이 와서 완료된 경우
+  // 2. 발주한 물품을 취소하는 경우
+  update = async (orderId, state) => {
+    if (!ValidationCheck(orderItemState, state)) {
+      return {
+        code: 400,
+        message: Messages.WrongState,
+      };
     }
 
-    return await this._placeOrderItemsRepository.create(itemName, amount);
+    const orderReceipt = await this._placeOrderItemsRepository.findReceipt(
+      orderId,
+    );
+    if (!orderReceipt) {
+      return {
+        code: 400,
+        message: Messages.NoneExistOrder,
+      };
+    }
+    // 현재 상태와 변경 상태가 동일한 경우 바꿀 필요 없음
+    if (state === orderReceipt.state) {
+      return {
+        code: 400,
+        message: Messages.CannotChangeState,
+      };
+    }
+
+    // 취소된 주문은 완료시킬 수 없음
+    if (
+      state === orderItemState.complete &&
+      orderReceipt.state === orderItemState.cancel
+    ) {
+      return {
+        code: 400,
+        message: Messages.CannotChangeState,
+      };
+    }
+
+    // 완료된 주문은 취소시킬 수 없음
+    if (
+      state === orderItemState.cancel &&
+      orderReceipt.state === orderItemState.complete
+    ) {
+      return {
+        code: 400,
+        message: Messages.CannotChangeState,
+      };
+    }
+
+    // 주문이 완료되는 경우
+    if (
+      state === orderItemState.complete &&
+      orderReceipt.state === orderItemState.ordered
+    ) {
+      await this._itemRepo.updateItemAmount(
+        orderReceipt.itemId,
+        orderReceipt.amount,
+      );
+      await this._placeOrderItemsRepository.updateState(orderId, state);
+      // 트랜잭션 적용할 예정
+      return {
+        code: 200,
+      };
+    }
+
+    // 주문을 취소하는 경우
+    if (
+      state === orderItemState.cancel &&
+      orderReceipt.state === orderItemState.ordered
+    ) {
+      await this._placeOrderItemsRepository.updateState(orderId, state);
+    }
   };
 }


### PR DESCRIPTION
이전 메뉴 추가와 같은 형식의 코드 리팩토링
1. 발주서 만들기 : 무조건 만들면 ordered (0) 으로 생성됨 => 주문하자마자 취소되거나 완료될 일 없음

2. 발주서 수정 : 주문 => 취소 or 완료 되는 일만 가정 => 취소된 발주가 완료되는 일 없음 => 완료된 발주가 취소되는 일 없음 => 같은 발주상태(state) 가 변경되는 일 없음

3. 발주서 생성 시 이름으로 생성하려 시도했으나 실패 => SELECT * FROM item WHERE name = ?, [name] 으로 execute => 그러나 error가 뜨면서 계속 sql문 자체가 undefined로 뜸

4. 발주서 생성 시 메뉴의 아이디로 생성하는 것으로 노선 변경 => SELECT * FROM item WHERE id = ?, [id] 로 execute => 왜 name은 안되고 id는 되는지 잘 모르겠음 => 쿼리문을 sql에서 직접 실행했을때는 잘 실행됨 => .query()는 사용을 자제할 것 => 강제 주입으로 인해 외부의 공격을 받을 수 있음 => const id = 1 => result = "SELECT * FROM item WHERE id =${id}" => 그런데 const id = "1 DROP TABLE item" => 하면 테이블이 삭제됨

5. 현재 place_order 테이블의 state의 type 은 tinyint로 숫자로 관리할 수 있음 따라서 state 를 0=oredered, 1=cancel, 2=complete로 변경